### PR TITLE
Add notebook references to function docstrings

### DIFF
--- a/shm_function_selector/src/index.ts
+++ b/shm_function_selector/src/index.ts
@@ -1780,7 +1780,7 @@ class SHMFunctionSelector {
       `;
 
       const verboseCallLabel = document.createElement('div');
-      verboseCallLabel.textContent = 'Usage Example:';
+      verboseCallLabel.textContent = 'Verbose Call Signature:';
       verboseCallLabel.style.cssText = `
         color: #666;
         font-size: 11px;

--- a/shmtools/active_sensing/geometry.py
+++ b/shmtools/active_sensing/geometry.py
@@ -295,6 +295,7 @@ def build_contained_grid_shm(
         :verbose_call: [Grid Points, Points of Interest Mask, X Matrix, Y Matrix] = Build Contained Grid (Border Structure, X Spacing, Y Spacing)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     border_struct : list of array_like
@@ -411,6 +412,7 @@ def sensor_pair_line_of_sight_shm(
         :verbose_call: [Line of Sight Matrix] = Sensor Pair Line of Sight (Pair List, Sensor Layout, Points of Interest, Border)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     pair_list : array_like

--- a/shmtools/active_sensing/geometry.py
+++ b/shmtools/active_sensing/geometry.py
@@ -294,6 +294,7 @@ def build_contained_grid_shm(
         :display_name: Build Contained Grid
         :verbose_call: [Grid Points, Points of Interest Mask, X Matrix, Y Matrix] = Build Contained Grid (Border Structure, X Spacing, Y Spacing)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     border_struct : list of array_like
@@ -409,6 +410,7 @@ def sensor_pair_line_of_sight_shm(
         :display_name: Sensor Pair Line of Sight
         :verbose_call: [Line of Sight Matrix] = Sensor Pair Line of Sight (Pair List, Sensor Layout, Points of Interest, Border)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     pair_list : array_like

--- a/shmtools/active_sensing/matched_filter.py
+++ b/shmtools/active_sensing/matched_filter.py
@@ -137,6 +137,7 @@ def incoherent_matched_filter_shm(
         :verbose_call: Filter Result = Incoherent Matched Filter (Waveform, Matched Waveform)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     waveform : array_like

--- a/shmtools/active_sensing/matched_filter.py
+++ b/shmtools/active_sensing/matched_filter.py
@@ -136,6 +136,7 @@ def incoherent_matched_filter_shm(
         :display_name: Incoherent Matched Filter
         :verbose_call: Filter Result = Incoherent Matched Filter (Waveform, Matched Waveform)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     waveform : array_like

--- a/shmtools/active_sensing/utilities.py
+++ b/shmtools/active_sensing/utilities.py
@@ -25,6 +25,7 @@ def extract_subsets_shm(
         :verbose_call: Data Subsets = Extract Subsets (Data, Start Indices, Subset Window)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     data : array_like
@@ -211,6 +212,7 @@ def flex_logic_filter_shm(
         :verbose_call: Filtered Data = Flexible Logic Filter (Data, Logic Filter, Dimensions)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     data : array_like
@@ -308,6 +310,7 @@ def sum_mult_dims_shm(data: np.ndarray, dimensions: List[int]) -> np.ndarray:
         :verbose_call: [Data Sum] = Sum Multiple Dimensions (Data, Dimensions)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     data : array_like
@@ -380,6 +383,7 @@ def estimate_group_velocity_shm(
         :verbose_call: [Estimated Speed, Speed List] = Estimate Wavespeed (Waveform, Pair List, Sensor Layout, Sampling Rate, Actuation Width, Line of Sight)
 
         :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
+
     Parameters
     ----------
     waveform : array_like

--- a/shmtools/active_sensing/utilities.py
+++ b/shmtools/active_sensing/utilities.py
@@ -24,6 +24,7 @@ def extract_subsets_shm(
         :display_name: Extract Subsets
         :verbose_call: Data Subsets = Extract Subsets (Data, Start Indices, Subset Window)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     data : array_like
@@ -209,6 +210,7 @@ def flex_logic_filter_shm(
         :display_name: Flexible Logic Filter
         :verbose_call: Filtered Data = Flexible Logic Filter (Data, Logic Filter, Dimensions)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     data : array_like
@@ -305,6 +307,7 @@ def sum_mult_dims_shm(data: np.ndarray, dimensions: List[int]) -> np.ndarray:
         :display_name: Sum Multiple Dimensions
         :verbose_call: [Data Sum] = Sum Multiple Dimensions (Data, Dimensions)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     data : array_like
@@ -376,6 +379,7 @@ def estimate_group_velocity_shm(
         :display_name: Estimate Wavespeed
         :verbose_call: [Estimated Speed, Speed List] = Estimate Wavespeed (Waveform, Pair List, Sensor Layout, Sampling Rate, Actuation Width, Line of Sight)
 
+        :example_notebooks: ["active_sensing_feature_extraction.ipynb"]
     Parameters
     ----------
     waveform : array_like

--- a/shmtools/classification/custom_detector_assembly.py
+++ b/shmtools/classification/custom_detector_assembly.py
@@ -42,6 +42,7 @@ def assemble_outlier_detector_shm(
     2. Non-parametric Detectors: Kernel density estimation with various kernels
     3. Semi-parametric Detectors: Gaussian Mixture Models with partitioning
 
+        :example_notebooks: ["custom_detector_assembly.ipynb"]
     Parameters
     ----------
     suffix : str, optional

--- a/shmtools/classification/custom_detector_assembly.py
+++ b/shmtools/classification/custom_detector_assembly.py
@@ -43,6 +43,7 @@ def assemble_outlier_detector_shm(
     3. Semi-parametric Detectors: Gaussian Mixture Models with partitioning
 
         :example_notebooks: ["custom_detector_assembly.ipynb"]
+
     Parameters
     ----------
     suffix : str, optional

--- a/shmtools/classification/high_level_detection.py
+++ b/shmtools/classification/high_level_detection.py
@@ -39,6 +39,7 @@ def train_outlier_detector_shm(
         :display_name: Train Outlier Detector
         :verbose_call: [Models] = Train Outlier Detector (Training Features, Number of Clusters, Confidence, Model File Name, Distribution Type)
 
+        :example_notebooks: ["how_to_use_default_detectors.ipynb"]
     Parameters
     ----------
     X_good : array_like
@@ -221,6 +222,7 @@ def detect_outlier_shm(
         :display_name: Detect Outlier
         :verbose_call: [Results, Confidences, Scores, Threshold] = Detect Outlier (Test Features, Model File Name, Models, Threshold, Sensor Codes)
 
+        :example_notebooks: ["custom_detector_assembly.ipynb", "how_to_use_default_detectors.ipynb"]
     Parameters
     ----------
     X_test : array_like

--- a/shmtools/classification/high_level_detection.py
+++ b/shmtools/classification/high_level_detection.py
@@ -40,6 +40,7 @@ def train_outlier_detector_shm(
         :verbose_call: [Models] = Train Outlier Detector (Training Features, Number of Clusters, Confidence, Model File Name, Distribution Type)
 
         :example_notebooks: ["how_to_use_default_detectors.ipynb"]
+
     Parameters
     ----------
     X_good : array_like
@@ -223,6 +224,7 @@ def detect_outlier_shm(
         :verbose_call: [Results, Confidences, Scores, Threshold] = Detect Outlier (Test Features, Model File Name, Models, Threshold, Sensor Codes)
 
         :example_notebooks: ["custom_detector_assembly.ipynb", "how_to_use_default_detectors.ipynb"]
+
     Parameters
     ----------
     X_test : array_like

--- a/shmtools/classification/nlpca.py
+++ b/shmtools/classification/nlpca.py
@@ -54,6 +54,7 @@ def learn_nlpca_shm(
         :output_type: Model
 
         :example_notebooks: ["nlpca_outlier_detection.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -247,6 +248,7 @@ def score_nlpca_shm(
         :output_type: Scores
 
         :example_notebooks: ["nlpca_outlier_detection.ipynb"]
+
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/nlpca.py
+++ b/shmtools/classification/nlpca.py
@@ -53,6 +53,7 @@ def learn_nlpca_shm(
         :data_type: Features
         :output_type: Model
 
+        :example_notebooks: ["nlpca_outlier_detection.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -245,6 +246,7 @@ def score_nlpca_shm(
         :data_type: Features
         :output_type: Scores
 
+        :example_notebooks: ["nlpca_outlier_detection.ipynb"]
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/nonparametric.py
+++ b/shmtools/classification/nonparametric.py
@@ -408,6 +408,7 @@ def learn_kernel_density_shm(
         :display_name: Learn Kernel Density Estimation
         :verbose_call: Model = Learn Kernel Density Estimation (Training Features, Bandwidth Matrix, Kernel Function, Bandwidth Selection Method)
 
+        :example_notebooks: ["direct_use_nonparametric.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -505,6 +506,7 @@ def score_kernel_density_shm(
         :display_name: Score Kernel Density Estimation
         :verbose_call: Density Scores = Score Kernel Density Estimation (Test Features, Model, Use Log Densities)
 
+        :example_notebooks: ["direct_use_nonparametric.ipynb"]
     Parameters
     ----------
     Y : array_like
@@ -798,6 +800,7 @@ def learn_fast_metric_kernel_density_shm(
         :display_name: Learn Fast Metric Kernel Density
         :verbose_call: Model = Learn Fast Metric Kernel Density (Training Features, Bandwidth, Kernel Type, Distance Metric)
 
+        :example_notebooks: ["fast_metric_kernel_density.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -896,6 +899,7 @@ def score_fast_metric_kernel_density_shm(
         :display_name: Score Fast Metric Kernel Density
         :verbose_call: Density Scores = Score Fast Metric Kernel Density (Test Features, Model)
 
+        :example_notebooks: ["fast_metric_kernel_density.ipynb"]
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/nonparametric.py
+++ b/shmtools/classification/nonparametric.py
@@ -409,6 +409,7 @@ def learn_kernel_density_shm(
         :verbose_call: Model = Learn Kernel Density Estimation (Training Features, Bandwidth Matrix, Kernel Function, Bandwidth Selection Method)
 
         :example_notebooks: ["direct_use_nonparametric.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -507,6 +508,7 @@ def score_kernel_density_shm(
         :verbose_call: Density Scores = Score Kernel Density Estimation (Test Features, Model, Use Log Densities)
 
         :example_notebooks: ["direct_use_nonparametric.ipynb"]
+
     Parameters
     ----------
     Y : array_like
@@ -801,6 +803,7 @@ def learn_fast_metric_kernel_density_shm(
         :verbose_call: Model = Learn Fast Metric Kernel Density (Training Features, Bandwidth, Kernel Type, Distance Metric)
 
         :example_notebooks: ["fast_metric_kernel_density.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -900,6 +903,7 @@ def score_fast_metric_kernel_density_shm(
         :verbose_call: Density Scores = Score Fast Metric Kernel Density (Test Features, Model)
 
         :example_notebooks: ["fast_metric_kernel_density.ipynb"]
+
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/outlier_detection.py
+++ b/shmtools/classification/outlier_detection.py
@@ -25,6 +25,7 @@ def learn_mahalanobis_shm(X: np.ndarray) -> Dict[str, Any]:
         :display_name: Learn Mahalanobis
         :verbose_call: [Model] = Learn Mahalanobis (Training Features)
 
+        :example_notebooks: ["chi_square_outlier_detection.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "data_normalization_modal_properties.ipynb", "final_validation.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -87,6 +88,7 @@ def score_mahalanobis_shm(Y: np.ndarray, model: Dict[str, Any]) -> np.ndarray:
         :display_name: Score Mahalanobis
         :verbose_call: [Scores] = Score Mahalanobis (Test Features, Model)
 
+        :example_notebooks: ["chi_square_outlier_detection.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "data_normalization_modal_properties.ipynb", "final_validation.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     Y : array_like
@@ -168,6 +170,7 @@ def learn_svd_shm(X: np.ndarray, param_stand: bool = True) -> Dict[str, Any]:
         :display_name: Learn Singular Value Decomposition
         :verbose_call: [Model] = Learn Singular Value Decomposition (Training Features, Standardization)
 
+        :example_notebooks: ["svd_outlier_detection.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -254,6 +257,7 @@ def score_svd_shm(
         :display_name: Score Singular Value Decomposition
         :verbose_call: [Scores, Residuals] = Score Singular Value Decomposition (Test Features, SVD Model)
 
+        :example_notebooks: ["svd_outlier_detection.ipynb"]
     Parameters
     ----------
     Y : array_like
@@ -346,6 +350,7 @@ def learn_pca_shm(
         :display_name: Learn Principal Component Analysis
         :verbose_call: [Model] = Learn Principal Component Analysis (Training Features, Percentage of Variance, Standardization)
 
+        :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "pca_outlier_detection.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -464,6 +469,7 @@ def score_pca_shm(
         :display_name: Score Principal Component Analysis
         :verbose_call: [Scores, Residuals] = Score Principal Component Analysis (Test Features, Model)
 
+        :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "pca_outlier_detection.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     Y : array_like
@@ -547,6 +553,7 @@ def roc_shm(
         :display_name: ROC Curve
         :verbose_call: [True Positive Rate, False Positive Rate] = ROC Curve (Scores, Damage States, Number of Points, Threshold Type)
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "custom_detector_assembly.ipynb", "data_normalization_modal_properties.ipynb", "direct_use_nonparametric.ipynb", "direct_use_semiparametric.ipynb", "factor_analysis_test.ipynb", "final_validation.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb", "how_to_use_default_detectors.ipynb", "svd_outlier_detection.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     scores : array_like
@@ -674,6 +681,7 @@ def learn_factor_analysis_shm(
         :display_name: Learn Factor Analysis
         :verbose_call: [Factor Analysis Model] = Learn Factor Analysis (Training Features, Number of Factors, Estimation Method)
 
+        :example_notebooks: ["factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -806,6 +814,7 @@ def score_factor_analysis_shm(
         :display_name: Score Factor Analysis
         :verbose_call: [Scores, Unique Factors, Factor Scores] = Score Factor Analysis (Test Features, Factor Analysis Model)
 
+        :example_notebooks: ["factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb"]
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/outlier_detection.py
+++ b/shmtools/classification/outlier_detection.py
@@ -26,6 +26,7 @@ def learn_mahalanobis_shm(X: np.ndarray) -> Dict[str, Any]:
         :verbose_call: [Model] = Learn Mahalanobis (Training Features)
 
         :example_notebooks: ["chi_square_outlier_detection.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "data_normalization_modal_properties.ipynb", "final_validation.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -89,6 +90,7 @@ def score_mahalanobis_shm(Y: np.ndarray, model: Dict[str, Any]) -> np.ndarray:
         :verbose_call: [Scores] = Score Mahalanobis (Test Features, Model)
 
         :example_notebooks: ["chi_square_outlier_detection.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "data_normalization_modal_properties.ipynb", "final_validation.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     Y : array_like
@@ -171,6 +173,7 @@ def learn_svd_shm(X: np.ndarray, param_stand: bool = True) -> Dict[str, Any]:
         :verbose_call: [Model] = Learn Singular Value Decomposition (Training Features, Standardization)
 
         :example_notebooks: ["svd_outlier_detection.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -258,6 +261,7 @@ def score_svd_shm(
         :verbose_call: [Scores, Residuals] = Score Singular Value Decomposition (Test Features, SVD Model)
 
         :example_notebooks: ["svd_outlier_detection.ipynb"]
+
     Parameters
     ----------
     Y : array_like
@@ -351,6 +355,7 @@ def learn_pca_shm(
         :verbose_call: [Model] = Learn Principal Component Analysis (Training Features, Percentage of Variance, Standardization)
 
         :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "pca_outlier_detection.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -470,6 +475,7 @@ def score_pca_shm(
         :verbose_call: [Scores, Residuals] = Score Principal Component Analysis (Test Features, Model)
 
         :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "pca_outlier_detection.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     Y : array_like
@@ -554,6 +560,7 @@ def roc_shm(
         :verbose_call: [True Positive Rate, False Positive Rate] = ROC Curve (Scores, Damage States, Number of Points, Threshold Type)
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "custom_detector_assembly.ipynb", "data_normalization_modal_properties.ipynb", "direct_use_nonparametric.ipynb", "direct_use_semiparametric.ipynb", "factor_analysis_test.ipynb", "final_validation.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb", "how_to_use_default_detectors.ipynb", "svd_outlier_detection.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     scores : array_like
@@ -682,6 +689,7 @@ def learn_factor_analysis_shm(
         :verbose_call: [Factor Analysis Model] = Learn Factor Analysis (Training Features, Number of Factors, Estimation Method)
 
         :example_notebooks: ["factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -815,6 +823,7 @@ def score_factor_analysis_shm(
         :verbose_call: [Scores, Unique Factors, Factor Scores] = Score Factor Analysis (Test Features, Factor Analysis Model)
 
         :example_notebooks: ["factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb"]
+
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/semiparametric.py
+++ b/shmtools/classification/semiparametric.py
@@ -245,6 +245,7 @@ def score_gmm_shm(
         :verbose_call: Density Scores = Score Gaussian Mixture Model (Test Features, Model, Use Log Densities)
 
         :example_notebooks: ["direct_use_semiparametric.ipynb"]
+
     Parameters
     ----------
     Y : array_like
@@ -369,6 +370,7 @@ def learn_gmm_semiparametric_model_shm(
         :verbose_call: Density Model = Learn GMM semi-Parametric Density Model (Training Features, Partition Function, k)
 
         :example_notebooks: ["direct_use_semiparametric.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -453,6 +455,7 @@ def score_gmm_semiparametric_model_shm(
         :verbose_call: Density Scores = Score GMM Semi-Parametric Density Model (Test Features, Model)
 
         :example_notebooks: ["direct_use_semiparametric.ipynb"]
+
     Parameters
     ----------
     Y : array_like

--- a/shmtools/classification/semiparametric.py
+++ b/shmtools/classification/semiparametric.py
@@ -244,6 +244,7 @@ def score_gmm_shm(
         :display_name: Score Gaussian Mixture Model
         :verbose_call: Density Scores = Score Gaussian Mixture Model (Test Features, Model, Use Log Densities)
 
+        :example_notebooks: ["direct_use_semiparametric.ipynb"]
     Parameters
     ----------
     Y : array_like
@@ -367,6 +368,7 @@ def learn_gmm_semiparametric_model_shm(
         :display_name: Learn GMM Semi-Parametric Density Model
         :verbose_call: Density Model = Learn GMM semi-Parametric Density Model (Training Features, Partition Function, k)
 
+        :example_notebooks: ["direct_use_semiparametric.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -450,6 +452,7 @@ def score_gmm_semiparametric_model_shm(
         :display_name: Score GMM Semi-Parametric Density Model
         :verbose_call: Density Scores = Score GMM Semi-Parametric Density Model (Test Features, Model)
 
+        :example_notebooks: ["direct_use_semiparametric.ipynb"]
     Parameters
     ----------
     Y : array_like

--- a/shmtools/core/preprocessing.py
+++ b/shmtools/core/preprocessing.py
@@ -168,6 +168,7 @@ def scale_min_max_shm(
         :output_type: Time Series
         :verbose_call: [Scaled Time Series Data] = Scale Minimum Maximum (Data Matrix, Dimension to Scale, Scale Range)
 
+        :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "svd_outlier_detection.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -385,6 +386,7 @@ def envelope_shm(X: np.ndarray) -> np.ndarray:
     method which looks at the spectral kurtosis of different frequency
     bands.
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -461,6 +463,7 @@ def demean_shm(X: np.ndarray) -> np.ndarray:
     removal or constant detrending. The mean is computed along the first
     dimension (time samples) for each channel and instance independently.
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -527,6 +530,7 @@ def filter_shm(X: np.ndarray, filter_coef: np.ndarray) -> np.ndarray:
     off the length of the signal such that the signal length of the input
     signal is equal to the signal length of the output signal.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -629,6 +633,7 @@ def window_shm(
     and the samples [1:N] are returned. 'SYMMETRIC' should be used for filter
     design and 'PERIODIC' is useful for DFT/FFT and spectral analysis.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     win_type : str

--- a/shmtools/core/preprocessing.py
+++ b/shmtools/core/preprocessing.py
@@ -169,6 +169,7 @@ def scale_min_max_shm(
         :verbose_call: [Scaled Time Series Data] = Scale Minimum Maximum (Data Matrix, Dimension to Scale, Scale Range)
 
         :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "svd_outlier_detection.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -387,6 +388,7 @@ def envelope_shm(X: np.ndarray) -> np.ndarray:
     bands.
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -464,6 +466,7 @@ def demean_shm(X: np.ndarray) -> np.ndarray:
     dimension (time samples) for each channel and instance independently.
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -531,6 +534,7 @@ def filter_shm(X: np.ndarray, filter_coef: np.ndarray) -> np.ndarray:
     signal is equal to the signal length of the output signal.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -634,6 +638,7 @@ def window_shm(
     design and 'PERIODIC' is useful for DFT/FFT and spectral analysis.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     win_type : str

--- a/shmtools/core/signal_processing.py
+++ b/shmtools/core/signal_processing.py
@@ -36,6 +36,7 @@ def ars_tach_shm(
         :verbose_call: [Angular Resampled Signal, Angular Domain] = Angular Resampling from Tachometer (Signal Matrix, Tachometer Signal, Sampling Frequency, Pulses Per Revolution, Gear Ratio, Angular Resolution)
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     data : array_like, shape (n_samples,) or (n_samples, n_channels)

--- a/shmtools/core/signal_processing.py
+++ b/shmtools/core/signal_processing.py
@@ -35,6 +35,7 @@ def ars_tach_shm(
         :rotating_machinery: True
         :verbose_call: [Angular Resampled Signal, Angular Domain] = Angular Resampling from Tachometer (Signal Matrix, Tachometer Signal, Sampling Frequency, Pulses Per Revolution, Gear Ratio, Angular Resolution)
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     data : array_like, shape (n_samples,) or (n_samples, n_channels)

--- a/shmtools/core/spectral.py
+++ b/shmtools/core/spectral.py
@@ -38,6 +38,7 @@ def psd_welch_shm(
     a signal. Typically the number of overlapping segments should be
     between 50 to 75 percent of the window length.
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -210,6 +211,7 @@ def stft_shm(
         :display_name: Short-Time Fourier Transform
         :verbose_call: [Frequency, Time, STFT] = Short-Time Fourier Transform (Signal, Sampling Rate, Window, Segment Length, Overlap, FFT Length)
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -858,6 +860,7 @@ def hoelder_exp_shm(scalo_matrix: np.ndarray, f: np.ndarray) -> np.ndarray:
     the slope. This allows for non-linearities to be more easily detected in
     vibration signals.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     scalo_matrix : ndarray, shape (n_freq, time, channels, instances)
@@ -1019,6 +1022,7 @@ def dwvd_shm(
     negative values which are not actually present in the signal being
     analyzed.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -1269,6 +1273,7 @@ def lpc_spectrogram_shm(
     the spectral envelope, providing better frequency resolution than
     traditional periodogram-based methods.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)

--- a/shmtools/core/spectral.py
+++ b/shmtools/core/spectral.py
@@ -39,6 +39,7 @@ def psd_welch_shm(
     between 50 to 75 percent of the window length.
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -212,6 +213,7 @@ def stft_shm(
         :verbose_call: [Frequency, Time, STFT] = Short-Time Fourier Transform (Signal, Sampling Rate, Window, Segment Length, Overlap, FFT Length)
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -861,6 +863,7 @@ def hoelder_exp_shm(scalo_matrix: np.ndarray, f: np.ndarray) -> np.ndarray:
     vibration signals.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     scalo_matrix : ndarray, shape (n_freq, time, channels, instances)
@@ -1023,6 +1026,7 @@ def dwvd_shm(
     analyzed.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -1274,6 +1278,7 @@ def lpc_spectrogram_shm(
     traditional periodogram-based methods.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)

--- a/shmtools/core/statistics.py
+++ b/shmtools/core/statistics.py
@@ -475,6 +475,7 @@ def crest_factor_shm(X: np.ndarray) -> np.ndarray:
     crest factor has been found to be more sensitive to damage incurred in
     early stages of gear and bearing failure.
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -552,6 +553,7 @@ def stat_moments_shm(X: np.ndarray) -> np.ndarray:
     Returns the first four statistical moments as damage sensitive features:
     (1) mean, (2) standard deviation, (3) skewness, (4) kurtosis
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb", "nlpca_outlier_detection.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -643,6 +645,7 @@ def rms_shm(X: np.ndarray) -> np.ndarray:
         :display_name: Root Mean Square Feature
         :verbose_call: [RMS Feature Matrix] = Root Mean Square Feature (Signal Matrix)
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)

--- a/shmtools/core/statistics.py
+++ b/shmtools/core/statistics.py
@@ -476,6 +476,7 @@ def crest_factor_shm(X: np.ndarray) -> np.ndarray:
     early stages of gear and bearing failure.
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)
@@ -554,6 +555,7 @@ def stat_moments_shm(X: np.ndarray) -> np.ndarray:
     (1) mean, (2) standard deviation, (3) skewness, (4) kurtosis
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb", "gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb", "nlpca_outlier_detection.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (time, channels, instances)
@@ -646,6 +648,7 @@ def rms_shm(X: np.ndarray) -> np.ndarray:
         :verbose_call: [RMS Feature Matrix] = Root Mean Square Feature (Signal Matrix)
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     X : ndarray, shape (samples, channels, instances)

--- a/shmtools/features/condition_based_monitoring.py
+++ b/shmtools/features/condition_based_monitoring.py
@@ -22,6 +22,7 @@ def time_sync_avg_shm(x_ars_matrix: np.ndarray, samples_per_rev: int) -> np.ndar
         :display_name: Time Synchronous Average
         :verbose_call: [TSA Matrix] = Time Sync Avg (Angular Matrix, SPR)
 
+        :example_notebooks: ["time_synchronous_averaging_demo.ipynb"]
     Parameters
     ----------
     x_ars_matrix : array_like

--- a/shmtools/features/condition_based_monitoring.py
+++ b/shmtools/features/condition_based_monitoring.py
@@ -23,6 +23,7 @@ def time_sync_avg_shm(x_ars_matrix: np.ndarray, samples_per_rev: int) -> np.ndar
         :verbose_call: [TSA Matrix] = Time Sync Avg (Angular Matrix, SPR)
 
         :example_notebooks: ["time_synchronous_averaging_demo.ipynb"]
+
     Parameters
     ----------
     x_ars_matrix : array_like

--- a/shmtools/features/time_series.py
+++ b/shmtools/features/time_series.py
@@ -25,6 +25,7 @@ def ar_model_shm(
         :display_name: AR Model
         :verbose_call: [AR Parameters Feature Vectors, RMS Residuals Feature Vectors, AR Parameters, AR Residuals, AR Prediction] = AR Model (Time Series Data, AR Model Order)
 
+        :example_notebooks: ["ar_model_order_selection.ipynb", "chi_square_outlier_detection.ipynb", "custom_detector_assembly.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "direct_use_nonparametric.ipynb", "direct_use_semiparametric.ipynb", "factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb", "how_to_use_default_detectors.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "pca_outlier_detection.ipynb", "svd_outlier_detection.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -219,6 +220,7 @@ def ar_model_order_shm(
         :display_name: AR Model Order
         :verbose_call: [Mean AR Order, AR Orders, Model] = AR Model Order (Time Series Data, Method, Maximum AR Order, Tolerance)
 
+        :example_notebooks: ["ar_model_order_selection.ipynb", "ni_ultrasonic_daq.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -471,6 +473,7 @@ def arx_model_shm(
         :display_name: ARX Model
         :verbose_call: [ARX Parameters Feature Vectors, RMS Residuals Feature Vectors, ARX Parameters, ARX Residuals, ARX Prediction, ARX Model Orders] = ARX Model (Time Series Data, ARX Model Orders)
 
+        :example_notebooks: ["damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb"]
     Parameters
     ----------
     X : array_like
@@ -764,6 +767,7 @@ def split_features_shm(
         :display_name: Split Features Into Training and Scoring
         :verbose_call: [Training Features, Scoring Features, All Features] = Split Features Into Training and Scoring (Features, Training Indices, Scoring Indices, Feature Indices to Use)
 
+        :example_notebooks: ["chi_square_outlier_detection.ipynb"]
     Parameters
     ----------
     features : array_like

--- a/shmtools/features/time_series.py
+++ b/shmtools/features/time_series.py
@@ -26,6 +26,7 @@ def ar_model_shm(
         :verbose_call: [AR Parameters Feature Vectors, RMS Residuals Feature Vectors, AR Parameters, AR Residuals, AR Prediction] = AR Model (Time Series Data, AR Model Order)
 
         :example_notebooks: ["ar_model_order_selection.ipynb", "chi_square_outlier_detection.ipynb", "custom_detector_assembly.ipynb", "damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb", "daq_ar_mahalanobis_integration.ipynb", "direct_use_nonparametric.ipynb", "direct_use_semiparametric.ipynb", "factor_analysis_final_validated.ipynb", "factor_analysis_outlier_detection.ipynb", "factor_analysis_test.ipynb", "how_to_use_default_detectors.ipynb", "mahalanobis_outlier_detection.ipynb", "ni_ultrasonic_daq.ipynb", "pca_outlier_detection.ipynb", "svd_outlier_detection.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -221,6 +222,7 @@ def ar_model_order_shm(
         :verbose_call: [Mean AR Order, AR Orders, Model] = AR Model Order (Time Series Data, Method, Maximum AR Order, Tolerance)
 
         :example_notebooks: ["ar_model_order_selection.ipynb", "ni_ultrasonic_daq.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -474,6 +476,7 @@ def arx_model_shm(
         :verbose_call: [ARX Parameters Feature Vectors, RMS Residuals Feature Vectors, ARX Parameters, ARX Residuals, ARX Prediction, ARX Model Orders] = ARX Model (Time Series Data, ARX Model Orders)
 
         :example_notebooks: ["damage_localization_ar_arx.ipynb", "damage_localization_ar_arx_executed.ipynb", "damage_localization_ar_arx_fixed.ipynb"]
+
     Parameters
     ----------
     X : array_like
@@ -768,6 +771,7 @@ def split_features_shm(
         :verbose_call: [Training Features, Scoring Features, All Features] = Split Features Into Training and Scoring (Features, Training Indices, Scoring Indices, Feature Indices to Use)
 
         :example_notebooks: ["chi_square_outlier_detection.ipynb"]
+
     Parameters
     ----------
     features : array_like

--- a/shmtools/hardware/signal_generation.py
+++ b/shmtools/hardware/signal_generation.py
@@ -25,6 +25,7 @@ def band_lim_white_noise_shm(
         :display_name: Band-Limited White Noise
         :verbose_call: [Excitation Signal] = Band-Limited White Noise (Array Size, Cutoff Frequencies, RMS Level, Filter Order)
 
+        :example_notebooks: ["ni_ultrasonic_daq.ipynb"]
     Parameters
     ----------
     array_size : tuple of int

--- a/shmtools/hardware/signal_generation.py
+++ b/shmtools/hardware/signal_generation.py
@@ -26,6 +26,7 @@ def band_lim_white_noise_shm(
         :verbose_call: [Excitation Signal] = Band-Limited White Noise (Array Size, Cutoff Frequencies, RMS Level, Filter Order)
 
         :example_notebooks: ["ni_ultrasonic_daq.ipynb"]
+
     Parameters
     ----------
     array_size : tuple of int

--- a/shmtools/modal/modal_analysis.py
+++ b/shmtools/modal/modal_analysis.py
@@ -45,6 +45,7 @@ def frf_shm(
         :output_type: Frequency Response
 
         :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     data : array_like
@@ -228,6 +229,7 @@ def rpfit_shm(
         :output_type: Modal Parameters
 
         :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "temp_final_test.ipynb"]
+
     Parameters
     ----------
     frf_data : array_like

--- a/shmtools/modal/modal_analysis.py
+++ b/shmtools/modal/modal_analysis.py
@@ -44,6 +44,7 @@ def frf_shm(
         :data_type: Time Series
         :output_type: Frequency Response
 
+        :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     data : array_like
@@ -226,6 +227,7 @@ def rpfit_shm(
         :data_type: Frequency Response
         :output_type: Modal Parameters
 
+        :example_notebooks: ["data_normalization_modal_properties.ipynb", "final_validation.ipynb", "temp_final_test.ipynb"]
     Parameters
     ----------
     frf_data : array_like

--- a/shmtools/modal/osp.py
+++ b/shmtools/modal/osp.py
@@ -32,6 +32,7 @@ def response_interp_shm(
         :display_name: Response Interpolation
         :verbose_call: [Response XYZ] = Response Interpolation (Geometry Layout, Displacement Vector, Response DOF, Use 3D Interpolation)
 
+        :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
     Parameters
     ----------
     geom_layout : array_like, shape (n_nodes, 3) or (4, n_nodes)
@@ -200,6 +201,7 @@ def osp_fisher_info_eiv_shm(
         :display_name: OSP Fisher Information EI
         :verbose_call: [Optimal DOF List, Determinant Q] = OSP Fisher Information EI (Number of Sensors, Mode Shapes, Covariance Matrix)
 
+        :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
     Parameters
     ----------
     num_sensors : int
@@ -343,6 +345,7 @@ def get_sensor_layout_shm(
         :display_name: Get Sensor Layout
         :verbose_call: [Sensor Layout] = Get Sensor Layout (Optimal DOF List, Response DOF, Node Layout)
 
+        :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
     Parameters
     ----------
     op_list : array_like, shape (n_sensors,)
@@ -423,6 +426,7 @@ def osp_max_norm_shm(
         :display_name: OSP Maximum Norm
         :verbose_call: [Optimal DOF List] = OSP Maximum Norm (Number of Sensors, Mode Shapes, Weights, Dualing Distance, Response DOF, Geometry Layout)
 
+        :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
     Parameters
     ----------
     num_sensors : int

--- a/shmtools/modal/osp.py
+++ b/shmtools/modal/osp.py
@@ -33,6 +33,7 @@ def response_interp_shm(
         :verbose_call: [Response XYZ] = Response Interpolation (Geometry Layout, Displacement Vector, Response DOF, Use 3D Interpolation)
 
         :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
+
     Parameters
     ----------
     geom_layout : array_like, shape (n_nodes, 3) or (4, n_nodes)
@@ -202,6 +203,7 @@ def osp_fisher_info_eiv_shm(
         :verbose_call: [Optimal DOF List, Determinant Q] = OSP Fisher Information EI (Number of Sensors, Mode Shapes, Covariance Matrix)
 
         :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
+
     Parameters
     ----------
     num_sensors : int
@@ -346,6 +348,7 @@ def get_sensor_layout_shm(
         :verbose_call: [Sensor Layout] = Get Sensor Layout (Optimal DOF List, Response DOF, Node Layout)
 
         :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
+
     Parameters
     ----------
     op_list : array_like, shape (n_sensors,)
@@ -427,6 +430,7 @@ def osp_max_norm_shm(
         :verbose_call: [Optimal DOF List] = OSP Maximum Norm (Number of Sensors, Mode Shapes, Weights, Dualing Distance, Response DOF, Geometry Layout)
 
         :example_notebooks: ["optimal_sensor_placement.ipynb", "optimal_sensor_placement_executed.ipynb", "optimal_sensor_placement_fixed.ipynb"]
+
     Parameters
     ----------
     num_sensors : int

--- a/shmtools/plotting/spectral_plots.py
+++ b/shmtools/plotting/spectral_plots.py
@@ -33,6 +33,7 @@ def plot_scores_shm(
         :display_name: Plot Detection Scores
         :verbose_call: [Axes Handle] = Plot Detection Scores (Scores, Detected States, State Names, Threshold, Use Bar Chart, Show Legend, Axes Handle)
 
+        :example_notebooks: ["ni_ultrasonic_daq.ipynb"]
     Parameters
     ----------
     scores : array_like, shape (n_tests,)
@@ -581,6 +582,7 @@ def plot_roc_shm(
     Plot receiver operating characteristic curve(s). A curve is plotted
     for each column of TPR and FPR.
 
+        :example_notebooks: ["ball_bearing_fault_analysis.ipynb"]
     Parameters
     ----------
     tpr : ndarray, shape (points, curves)
@@ -716,6 +718,7 @@ def plot_time_freq_shm(
     Create a time-frequency plot from output of lpcSpectrogram_shm,
     stft_shm or dwvd_shm.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     time_freq_matrix : ndarray, shape (freq, time, channels, instances)
@@ -898,6 +901,7 @@ def plot_scalogram_shm(
 
     Create a time-frequency plot from output of cwt_scalogram_shm.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     scalo_matrix : ndarray, shape (n_scale, time, channels, instances)
@@ -1328,6 +1332,7 @@ def plot_features_shm(
     distribution and characteristics of damage-sensitive features across
     different structural states or conditions.
 
+        :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
     Parameters
     ----------
     feature_vectors : ndarray, shape (instances, features)

--- a/shmtools/plotting/spectral_plots.py
+++ b/shmtools/plotting/spectral_plots.py
@@ -34,6 +34,7 @@ def plot_scores_shm(
         :verbose_call: [Axes Handle] = Plot Detection Scores (Scores, Detected States, State Names, Threshold, Use Bar Chart, Show Legend, Axes Handle)
 
         :example_notebooks: ["ni_ultrasonic_daq.ipynb"]
+
     Parameters
     ----------
     scores : array_like, shape (n_tests,)
@@ -583,6 +584,7 @@ def plot_roc_shm(
     for each column of TPR and FPR.
 
         :example_notebooks: ["ball_bearing_fault_analysis.ipynb"]
+
     Parameters
     ----------
     tpr : ndarray, shape (points, curves)
@@ -719,6 +721,7 @@ def plot_time_freq_shm(
     stft_shm or dwvd_shm.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     time_freq_matrix : ndarray, shape (freq, time, channels, instances)
@@ -902,6 +905,7 @@ def plot_scalogram_shm(
     Create a time-frequency plot from output of cwt_scalogram_shm.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     scalo_matrix : ndarray, shape (n_scale, time, channels, instances)
@@ -1333,6 +1337,7 @@ def plot_features_shm(
     different structural states or conditions.
 
         :example_notebooks: ["gearbox_fault_analysis.ipynb", "gearbox_fault_analysis_executed.ipynb", "gearbox_fault_analysis_test.ipynb"]
+
     Parameters
     ----------
     feature_vectors : ndarray, shape (instances, features)

--- a/shmtools/sensor_diagnostics/sensor_diagnostics.py
+++ b/shmtools/sensor_diagnostics/sensor_diagnostics.py
@@ -35,6 +35,7 @@ def sd_feature_shm(admittance_data: np.ndarray) -> np.ndarray:
         :data_type: Frequency Response
         :output_type: Features
 
+        :example_notebooks: ["sensor_diagnostics.ipynb"]
     Parameters
     ----------
     admittance_data : array_like
@@ -111,6 +112,7 @@ def sd_autoclassify_shm(
         :data_type: Features
         :output_type: Classification
 
+        :example_notebooks: ["sensor_diagnostics.ipynb"]
     Parameters
     ----------
     capacitance : array_like
@@ -281,6 +283,7 @@ def sd_plot_shm(data_for_plotting: Dict[str, Any]) -> None:
         :data_type: Plotting Data
         :output_type: Visualization
 
+        :example_notebooks: ["sensor_diagnostics.ipynb"]
     Parameters
     ----------
     data_for_plotting : dict

--- a/shmtools/sensor_diagnostics/sensor_diagnostics.py
+++ b/shmtools/sensor_diagnostics/sensor_diagnostics.py
@@ -36,6 +36,7 @@ def sd_feature_shm(admittance_data: np.ndarray) -> np.ndarray:
         :output_type: Features
 
         :example_notebooks: ["sensor_diagnostics.ipynb"]
+
     Parameters
     ----------
     admittance_data : array_like
@@ -113,6 +114,7 @@ def sd_autoclassify_shm(
         :output_type: Classification
 
         :example_notebooks: ["sensor_diagnostics.ipynb"]
+
     Parameters
     ----------
     capacitance : array_like
@@ -284,6 +286,7 @@ def sd_plot_shm(data_for_plotting: Dict[str, Any]) -> None:
         :output_type: Visualization
 
         :example_notebooks: ["sensor_diagnostics.ipynb"]
+
     Parameters
     ----------
     data_for_plotting : dict

--- a/update_notebook_references.py
+++ b/update_notebook_references.py
@@ -179,7 +179,7 @@ def update_function_docstring(file_path: Path, func_name: str, notebook_refs: Li
             
             # Insert the new line before the end of meta section
             notebooks_str = ', '.join([f'"{nb}"' for nb in notebook_refs])
-            new_line = f'{indent}:example_notebooks: [{notebooks_str}]\n'
+            new_line = f'{indent}:example_notebooks: [{notebooks_str}]\n\n'  # Added extra newline for spacing
             
             # Insert right before meta_end_idx
             new_lines.insert(meta_end_idx, new_line)

--- a/update_notebook_references.py
+++ b/update_notebook_references.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Script to scan all example notebooks and update function docstrings with notebook references.
+"""
+
+import os
+import re
+import json
+import ast
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+
+def find_notebooks(examples_dir: Path) -> List[Path]:
+    """Find all Jupyter notebooks in the examples directory."""
+    notebooks = []
+    for root, dirs, files in os.walk(examples_dir):
+        for file in files:
+            if file.endswith('.ipynb') and not file.startswith('Untitled') and 'checkpoint' not in file:
+                notebooks.append(Path(root) / file)
+    return notebooks
+
+
+def extract_function_calls_from_notebook(notebook_path: Path) -> Set[str]:
+    """Extract all shmtools function calls from a notebook."""
+    function_calls = set()
+    
+    try:
+        with open(notebook_path, 'r') as f:
+            notebook = json.load(f)
+        
+        for cell in notebook.get('cells', []):
+            if cell.get('cell_type') == 'code':
+                source = ''.join(cell.get('source', []))
+                
+                # Find direct function calls like function_name_shm(
+                pattern = r'\b([a-z_]+_shm)\s*\('
+                matches = re.findall(pattern, source)
+                function_calls.update(matches)
+                
+                # Also find imports
+                import_pattern = r'from\s+shmtools[.\w]*\s+import\s+([^#\n]+)'
+                import_matches = re.findall(import_pattern, source)
+                for import_match in import_matches:
+                    # Handle multiple imports
+                    funcs = [f.strip() for f in import_match.split(',')]
+                    for func in funcs:
+                        if '_shm' in func:
+                            function_calls.add(func.strip())
+    except Exception as e:
+        print(f"Error processing {notebook_path}: {e}")
+    
+    return function_calls
+
+
+def find_shmtools_functions(shmtools_dir: Path) -> Dict[str, Path]:
+    """Find all _shm functions in the shmtools directory."""
+    functions = {}
+    
+    for root, dirs, files in os.walk(shmtools_dir):
+        # Skip __pycache__ and .ipynb_checkpoints directories
+        if '__pycache__' in root or '.ipynb_checkpoints' in root:
+            continue
+            
+        for file in files:
+            if file.endswith('.py'):
+                file_path = Path(root) / file
+                try:
+                    with open(file_path, 'r') as f:
+                        content = f.read()
+                    
+                    # Find function definitions
+                    pattern = r'^def\s+([a-z_]+_shm)\s*\('
+                    matches = re.findall(pattern, content, re.MULTILINE)
+                    for match in matches:
+                        functions[match] = file_path
+                except Exception as e:
+                    print(f"Error reading {file_path}: {e}")
+    
+    return functions
+
+
+def create_notebook_mapping(notebooks: List[Path], shmtools_dir: Path) -> Dict[str, List[str]]:
+    """Create a mapping of functions to notebooks that use them."""
+    function_to_notebooks = {}
+    
+    # Get all functions
+    functions = find_shmtools_functions(shmtools_dir)
+    
+    # Initialize empty lists for all functions
+    for func_name in functions:
+        function_to_notebooks[func_name] = []
+    
+    # Scan each notebook
+    for notebook_path in notebooks:
+        print(f"Scanning {notebook_path.name}...")
+        function_calls = extract_function_calls_from_notebook(notebook_path)
+        
+        # Map function calls to notebooks
+        for func_name in function_calls:
+            if func_name in function_to_notebooks:
+                # Store just the filename, not the full path
+                notebook_name = notebook_path.name
+                if notebook_name not in function_to_notebooks[func_name]:
+                    function_to_notebooks[func_name].append(notebook_name)
+    
+    # Sort notebook names for consistency
+    for func_name in function_to_notebooks:
+        function_to_notebooks[func_name].sort()
+    
+    return function_to_notebooks
+
+
+def update_function_docstring(file_path: Path, func_name: str, notebook_refs: List[str]) -> bool:
+    """Update a function's docstring with notebook references."""
+    try:
+        with open(file_path, 'r') as f:
+            lines = f.readlines()
+        
+        # Find the function definition line
+        func_pattern = rf'^def\s+{re.escape(func_name)}\s*\('
+        func_line_idx = None
+        for i, line in enumerate(lines):
+            if re.match(func_pattern, line):
+                func_line_idx = i
+                break
+        
+        if func_line_idx is None:
+            print(f"Could not find function {func_name} in {file_path}")
+            return False
+        
+        # Find the docstring start (should be right after function definition)
+        docstring_start_idx = None
+        for i in range(func_line_idx + 1, min(func_line_idx + 10, len(lines))):
+            if '"""' in lines[i] or "'''" in lines[i]:
+                docstring_start_idx = i
+                break
+        
+        if docstring_start_idx is None:
+            print(f"No docstring found for {func_name}")
+            return False
+        
+        # Find the meta section
+        meta_line_idx = None
+        meta_end_idx = None
+        for i in range(docstring_start_idx, len(lines)):
+            if '.. meta::' in lines[i]:
+                meta_line_idx = i
+                # Find end of meta section (next section or end of docstring)
+                for j in range(i + 1, len(lines)):
+                    # Check for next section or end of docstring
+                    if (lines[j].strip().startswith('.. gui::') or 
+                        'Parameters' in lines[j] and '---' in lines[j+1] if j+1 < len(lines) else False or
+                        'Returns' in lines[j] and '---' in lines[j+1] if j+1 < len(lines) else False or
+                        '"""' in lines[j] or "'''" in lines[j]):
+                        meta_end_idx = j
+                        break
+                break
+        
+        if meta_line_idx is None:
+            print(f"No meta section found for {func_name}")
+            return False
+        
+        # Remove existing example_notebooks line if present
+        new_lines = lines.copy()
+        for i in range(meta_line_idx + 1, meta_end_idx):
+            if ':example_notebooks:' in lines[i]:
+                new_lines[i] = ''  # Remove the line
+        
+        # Add new example_notebooks line if we have references
+        if notebook_refs:
+            # Find the indentation of other meta fields
+            indent = '        '  # Default indentation
+            for i in range(meta_line_idx + 1, meta_end_idx):
+                if lines[i].strip().startswith(':'):
+                    # Extract indentation
+                    indent = lines[i][:lines[i].index(':')]
+                    break
+            
+            # Insert the new line before the end of meta section
+            notebooks_str = ', '.join([f'"{nb}"' for nb in notebook_refs])
+            new_line = f'{indent}:example_notebooks: [{notebooks_str}]\n'
+            
+            # Insert right before meta_end_idx
+            new_lines.insert(meta_end_idx, new_line)
+        
+        # Write back the file
+        with open(file_path, 'w') as f:
+            f.writelines(new_lines)
+        
+        return True
+    except Exception as e:
+        print(f"Error updating {func_name} in {file_path}: {e}")
+        return False
+
+
+def main():
+    """Main function to update all notebook references."""
+    # Set up paths
+    project_root = Path('/Users/eric/repo/shm')
+    shmtools_dir = project_root / 'shmtools'
+    examples_dir = project_root / 'examples'
+    
+    print("Finding all notebooks...")
+    notebooks = find_notebooks(examples_dir)
+    print(f"Found {len(notebooks)} notebooks")
+    
+    print("\nCreating function to notebook mapping...")
+    function_to_notebooks = create_notebook_mapping(notebooks, shmtools_dir)
+    
+    # Find all function files
+    functions = find_shmtools_functions(shmtools_dir)
+    
+    print(f"\nFound {len(functions)} functions")
+    print(f"Functions used in notebooks: {sum(1 for refs in function_to_notebooks.values() if refs)}")
+    
+    # Update each function's docstring
+    print("\nUpdating function docstrings...")
+    updated_count = 0
+    failed_count = 0
+    for func_name, file_path in functions.items():
+        notebook_refs = function_to_notebooks.get(func_name, [])
+        if notebook_refs:
+            print(f"Updating {func_name} with {len(notebook_refs)} notebook reference(s)")
+            if update_function_docstring(file_path, func_name, notebook_refs):
+                updated_count += 1
+            else:
+                failed_count += 1
+    
+    print(f"\nSuccessfully updated {updated_count} functions")
+    if failed_count > 0:
+        print(f"Failed to update {failed_count} functions")
+    
+    # Print summary
+    print("\n=== Summary ===")
+    print(f"Total notebooks scanned: {len(notebooks)}")
+    print(f"Total functions found: {len(functions)}")
+    print(f"Functions with notebook references: {sum(1 for refs in function_to_notebooks.values() if refs)}")
+    print(f"Functions updated: {updated_count}")
+    
+    # Print functions with most notebook references
+    sorted_funcs = sorted(
+        [(func, refs) for func, refs in function_to_notebooks.items() if refs],
+        key=lambda x: len(x[1]),
+        reverse=True
+    )
+    
+    if sorted_funcs:
+        print("\nTop 10 most-used functions:")
+        for func, refs in sorted_funcs[:10]:
+            print(f"  {func}: {len(refs)} notebook(s)")
+            print(f"    Notebooks: {', '.join(refs[:3])}{' ...' if len(refs) > 3 else ''}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Resolves #27

## Summary
- Created script to automatically scan example notebooks for function usage
- Added `example_notebooks` field to 62 function docstrings
- Shows which notebooks demonstrate each function for better discoverability

## Changes
- Added `update_notebook_references.py` script that:
  - Scans all 33 example notebooks
  - Finds function usage via imports and direct calls
  - Updates docstrings with notebook references (just filenames)
  - Maintains proper formatting with blank line before Parameters section

## Results
- Updated 62 out of 64 functions that are used in notebooks
- Most-used functions:
  - `ar_model_shm`: 17 notebooks
  - `roc_shm`: 13 notebooks  
  - `learn_mahalanobis_shm`: 10 notebooks
- Helps users find relevant examples for each function

🤖 Generated with [Claude Code](https://claude.ai/code)